### PR TITLE
Fixing Bug caused by NewLift Environment

### DIFF
--- a/robosuite_task_zoo/environments/manipulation/__init__.py
+++ b/robosuite_task_zoo/environments/manipulation/__init__.py
@@ -1,4 +1,3 @@
-from .new_lift import NewLift
 from .tool_use import ToolUseEnv
 from .hammer_place import HammerPlaceEnv
 from .kitchen import KitchenEnv


### PR DESCRIPTION
This pull request removes the NewLift environment from the __ init  __.py file within the manipulation folder. This causes errors since the environment is not actually available within the given folder. 

Note: a special thanks to the authors for making this repository available and including additional tasks from the BUDS paper.